### PR TITLE
Metrics usage

### DIFF
--- a/datadog/datadog_test.go
+++ b/datadog/datadog_test.go
@@ -108,3 +108,99 @@ func TestGetDashboards(t *testing.T) {
 	}
 	require.Equal(t, expected, summaries)
 }
+
+func TestGetMetrics(t *testing.T) {
+	requestCount := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		require.Equal(t, "GET", r.Method)
+		require.Equal(t, "/api/v1/metrics", r.URL.Path)
+		require.Equal(t, "api-key", r.URL.Query().Get("api_key"))
+		require.Equal(t, "app-key", r.URL.Query().Get("application_key"))
+		require.Equal(t, "1545717600", r.URL.Query().Get("from"))
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"metrics": [
+			  "system.load.1",
+			  "system.load.15",
+			  "system.load.5"
+			],
+			"from": "1467815773"
+		  }`)
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	api := API{
+		apiKey:  "api-key",
+		appKey:  "app-key",
+		baseURL: server.URL,
+	}
+
+	metrics, err := api.GetMetrics(time.Date(2018, 12, 25, 6, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Equal(t, 1, requestCount)
+
+	require.Equal(t, []string{
+		"system.load.1",
+		"system.load.15",
+		"system.load.5",
+	}, metrics)
+}
+
+func TestGetTopAverageMetrics(t *testing.T) {
+	requestCount := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		require.Equal(t, "GET", r.Method)
+		require.Equal(t, "/api/v1/usage/top_avg_metrics", r.URL.Path)
+		require.Equal(t, "api-key", r.URL.Query().Get("api_key"))
+		require.Equal(t, "app-key", r.URL.Query().Get("application_key"))
+		// this might fail if you get lucky and test it at midnight over a month boundary
+		thisMonth := fmt.Sprintf("%d-%02d", time.Now().Year(), time.Now().Month())
+		require.Equal(t, thisMonth, r.URL.Query().Get("month"))
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"usage": [
+			  {
+				"metric_category": "custom",
+				"metric_name": "custom.metric.1",
+				"max_metric_hour": 12786,
+				"avg_metric_hour": 7841
+			  },
+			  {
+				"metric_category": "custom",
+				"metric_name": "custom.metric.2",
+				"max_metric_hour": 10828,
+				"avg_metric_hour": 5986
+			  }]}`)
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	api := API{
+		apiKey:  "api-key",
+		appKey:  "app-key",
+		baseURL: server.URL,
+	}
+
+	usage, err := api.GetTopAverageMetrics()
+	require.NoError(t, err)
+	require.Equal(t, 1, requestCount)
+
+	expected := []MetricsUsage{
+		{
+			Category:   "custom",
+			Name:       "custom.metric.1",
+			MaxPerHour: 12786,
+			AvgPerHour: 7841,
+		}, {
+			Category:   "custom",
+			Name:       "custom.metric.2",
+			MaxPerHour: 10828,
+			AvgPerHour: 5986,
+		},
+	}
+
+	require.Equal(t, expected, usage)
+}

--- a/datadog/metrics.go
+++ b/datadog/metrics.go
@@ -1,0 +1,17 @@
+package datadog
+
+type metricsResponse struct {
+	Metrics []string `json:"metrics"`
+	From    string   `json:"from"`
+}
+
+type MetricsUsage struct {
+	Category   string `json:"metric_category"`
+	Name       string `json:"metric_name"`
+	MaxPerHour int    `json:"max_metric_hour"`
+	AvgPerHour int    `json:"avg_metric_hour"`
+}
+
+type metricsUsageResponse struct {
+	Usage []MetricsUsage `json:"usage"`
+}

--- a/export.go
+++ b/export.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/porty/ddcli/datadog"
 	"github.com/urfave/cli"
 )
 
@@ -21,18 +20,12 @@ func export(c *cli.Context) error {
 
 	outputDir := c.Args()[0]
 
-	apiKey := os.Getenv("DD_API_KEY")
-	appKey := os.Getenv("DD_APP_KEY")
-	if apiKey == "" || appKey == "" {
-		fmt.Println("DD_API_KEY and DD_APP_KEY required")
-		os.Exit(1)
-	}
+	dd := getAPI()
 
 	dashboardDir := path.Join(outputDir, "dashboards")
 	screenboardDir := path.Join(outputDir, "screenboards")
 	monitorsDir := path.Join(outputDir, "monitors")
 	createDirectories(dashboardDir, screenboardDir, monitorsDir)
-	dd := datadog.New(apiKey, appKey)
 
 	dashes, err := dd.GetDashboards()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/porty/ddcli/datadog"
 	"github.com/urfave/cli"
 )
 
@@ -14,6 +16,35 @@ func main() {
 			Name:   "export",
 			Usage:  "export Datadog config",
 			Action: export,
+		},
+		{
+			Name:  "metrics",
+			Usage: "metrics commands",
+			Subcommands: []cli.Command{
+				{
+					Name:   "active",
+					Usage:  "list active metrics from the specified duration",
+					Action: activeMetricsFromDuration,
+					Flags: []cli.Flag{
+						cli.DurationFlag{
+							Name:  "duration, d",
+							Usage: "Duration, e.g. 1hr, 2h45m",
+						},
+					},
+				},
+				{
+					Name:   "top500",
+					Usage:  "list top 500 custom metrics for the month",
+					Action: top500CustomMetrics,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "format, f",
+							Value: "csv",
+							Usage: "Format, either csv or md (markdown)",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,5 +17,18 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to run command: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+func getAPI() *datadog.API {
+	apiKey := os.Getenv("DD_API_KEY")
+	appKey := os.Getenv("DD_APP_KEY")
+	if apiKey == "" || appKey == "" {
+		fmt.Println("DD_API_KEY and DD_APP_KEY required")
+		os.Exit(1)
+	}
+	return datadog.New(apiKey, appKey)
 }

--- a/markdown/table_writer.go
+++ b/markdown/table_writer.go
@@ -1,0 +1,41 @@
+package markdown
+
+import (
+	"io"
+	"strings"
+)
+
+type TableWriter struct {
+	w             io.Writer
+	headerWritten bool
+}
+
+func NewTableWriter(w io.Writer) *TableWriter {
+	return &TableWriter{
+		w: w,
+	}
+}
+
+func (t *TableWriter) Write(record []string) error {
+	line := "| " + strings.Join(record, " | ") + " |\n"
+	if _, err := t.w.Write([]byte(line)); err != nil {
+		return err
+	}
+	if t.headerWritten {
+		return nil
+	}
+	t.headerWritten = true
+
+	dashes := make([]string, len(record))
+	for i := range dashes {
+		dashes[i] = "---"
+	}
+	line = "|" + strings.Join(dashes, "|") + "|\n"
+	if _, err := t.w.Write([]byte(line)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *TableWriter) Flush() {
+}

--- a/markdown/table_writer_test.go
+++ b/markdown/table_writer_test.go
@@ -1,0 +1,26 @@
+package markdown
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableWriter(t *testing.T) {
+	b := bytes.Buffer{}
+	w := NewTableWriter(&b)
+
+	require.NoError(t, w.Write([]string{"ID", "Name"}))
+	require.NoError(t, w.Write([]string{"1", "Freddy"}))
+	require.NoError(t, w.Write([]string{"2", "Sarah"}))
+	w.Flush()
+
+	actual := b.String()
+	expected := "| ID | Name |\n" +
+		"|---|---|\n" +
+		"| 1 | Freddy |\n" +
+		"| 2 | Sarah |\n"
+
+	require.Equal(t, expected, actual)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/porty/ddcli/markdown"
+	"github.com/urfave/cli"
+)
+
+func activeMetricsFromDuration(c *cli.Context) error {
+	api := getAPI()
+	dur := c.Duration("duration")
+	t := time.Now().Add(-1 * dur)
+
+	metrics, err := api.GetMetrics(t)
+	if err != nil {
+		return err
+	}
+	for _, metric := range metrics {
+		fmt.Println(metric)
+	}
+	return nil
+}
+
+type columnWriter interface {
+	Write([]string) error
+	Flush()
+}
+
+func top500CustomMetrics(c *cli.Context) error {
+	api := getAPI()
+
+	metrics, err := api.GetTopAverageMetrics()
+	if err != nil {
+		return err
+	}
+
+	var w columnWriter
+	if c.String("format") == "md" {
+		w = markdown.NewTableWriter(os.Stdout)
+	} else {
+		w = csv.NewWriter(os.Stdout)
+	}
+	if err := w.Write([]string{"Name", "Average per hour", "Max per hour"}); err != nil {
+		return errors.New("failed to write output: " + err.Error())
+	}
+
+	for _, m := range metrics {
+		if err := w.Write([]string{
+			m.Name,
+			strconv.Itoa(m.AvgPerHour),
+			strconv.Itoa(m.MaxPerHour),
+		}); err != nil {
+			return errors.New("failed to write output: " + err.Error())
+		}
+	}
+
+	w.Flush()
+	return nil
+}


### PR DESCRIPTION
Add some metrics usage APIs and subcommands:

```
$ ddcli metrics
NAME:
   ddcli metrics - metrics commands

USAGE:
   ddcli metrics command [command options] [arguments...]

COMMANDS:
     active  list active metrics from the specified duration
     top500  list top 500 custom metrics for the month
```

---

[Hourly usage of custom metrics](https://docs.datadoghq.com/api/?lang=bash#get-hourly-usage-for-custom-metrics)

```
$ ddcli metrics active --help
NAME:
   ddcli metrics active - list active metrics from the specified duration

USAGE:
   ddcli metrics active [command options] [arguments...]

OPTIONS:
   --duration value, -d value  Duration, e.g. 1hr, 2h45m (default: 0s)
```

---

[Get top 500 custom metrics by hourly average](https://docs.datadoghq.com/api/?lang=bash#get-top-500-custom-metrics-by-hourly-average)

```
$ ddcli metrics top500 --help
NAME:
   ddcli metrics top500 - list top 500 custom metrics for the month

USAGE:
   ddcli metrics top500 [command options] [arguments...]

OPTIONS:
   --format value, -f value  Format, either csv or md (markdown) (default: "csv")
```